### PR TITLE
Correct grammatical error of import in READEME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install use-draggable-scroll
 ### Usage
 
 ```tsx
-import { useDraggableScroll } from 'use-draggable-scroll';
+import useDraggableScroll from 'use-draggable-scroll';
 
 const Component = () => {
   const ref = useRef(null);


### PR DESCRIPTION
I find a syntax error in the import statement in the README.

Check it, please.
